### PR TITLE
.github/workflows: Use custom GH token for release publishing

### DIFF
--- a/.github/workflows/prepare-binaries.yml
+++ b/.github/workflows/prepare-binaries.yml
@@ -70,3 +70,4 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: ReleaseArtifacts/*
+        token: ${{ secrets.GH_UEFI_BOT_PUBLISH_TOKEN }}


### PR DESCRIPTION
Uses a custom token for publishing releases.