### PR TITLE
Fix dbx_info_msft_06_10_25.json cert file name

### DIFF
--- a/PreSignedObjects/DBX/dbx_info_msft_06_10_25.json
+++ b/PreSignedObjects/DBX/dbx_info_msft_06_10_25.json
@@ -6591,7 +6591,7 @@
 	},
     "certificates": [
         {
-            "value": "WindowsProduction2011.cer",
+            "value": "MicWinProPCA2011_2011-10-19.der",
             "subjectName": "CN = Microsoft Windows Production PCA 2011",
             "issuerName": "CN = Microsoft Root Certificate Authority 2010",
             "thumbprint": "580a6f4cc4e4b669b9ebdc1b2b3e087b80d0678d",


### PR DESCRIPTION
Fixes: eb36a9738de4 ("Updating DBX update package with the latest revocations")

## Description

eb36a9738de4 broke the dbx_info.json certificate file name again.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
