### PR TITLE
Update InstallSecureBootKeys.ps1

### DIFF
--- a/scripts/windows/InstallSecureBootKeys.ps1
+++ b/scripts/windows/InstallSecureBootKeys.ps1
@@ -85,7 +85,7 @@ try {
     }
 
     Log-Message "Enrolling DBX..." "Green"
-    $esult = Set-SecureBootUEFI -Time $time -ContentFilePath $DbxFilePath -Name dbx
+    $Result = Set-SecureBootUEFI -Time $time -ContentFilePath $DbxFilePath -Name dbx
     if ($null -ne $Result) {
         Log-Message "DBX enrolled successfully." "Green"
     } else {


### PR DESCRIPTION
Fixes microsoft/secureboot_objects#245


## Description

Changed "$esult" to "$Result" so that the script can properly determine if the DBX was enrolled successfully.


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a Dell Inspiron 3847 with the MicrosoftAndThirdParty/Firmware files from https://github.com/microsoft/secureboot_objects/releases/download/v1.5.1/edk2-x64-secureboot-binaries.zip and a customized DBX.bin file. 

## Integration Instructions

N/A
