### PR TITLE
Add cryptographic verification to authenticode_transplant.py

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -5,3 +5,4 @@ pytest==9.0.2
 pefile==2024.8.26
 pyasn1==0.6.2
 pyasn1_modules==0.4.2
+cryptography==43.0.0


### PR DESCRIPTION
This commit adds comprehensive cryptographic validation to the Authenticode signature combining tool, bringing the same verification capabilities from auth_var_tool.py to PE file signature operations.

Key changes:
- Added cryptographic signature verification using the 'cryptography' library
- Implemented SpcIndirectDataContent parsing to extract embedded PE hashes
- Added certificate extraction and display from PKCS#7 signatures
- Compute Authenticode hashes using the algorithm specified in the signature
- Verify signatures mathematically using signer's public key (RSA/ECDSA)
- Validate that computed PE hash matches the hash in SpcIndirectDataContent

New functions:
- _get_hash_algorithm_from_oid(): Maps OID strings to hash algorithms
- _extract_pe_hash_from_spc_indirect_data(): Parses SPC structure for hash
- _extract_certificates_from_pkcs7(): Extracts X.509 certificates
- _verify_pkcs7_signature(): Performs full cryptographic verification
- compute_authenticode_hash(): Flexible hash computation with configurable algorithm

Enhanced functions:
- validate_pkcs7_signatures(): Now performs cryptographic verification
- main_verify(): Displays certificate details and verification status
- main_combine(): Validates signatures cryptographically before combining

Bug fixes:
- Removed incorrect 8-byte padding from Authenticode hash calculation (padding only applies to WIN_CERTIFICATE structure alignment, not hash data)
- Consolidated duplicate hash functions into single implementation

Code improvements:
- Named constants for all magic numbers in SPC parsing
- Better documentation and inline comments
- Proper type annotations with Optional types

Testing:
- Verified against Microsoft-signed bootmgfw.efi files
- Hash computation now matches Windows AppLocker and UEFI firmware
- Both multi-signature and nested signature modes validated
- All test cases pass with cryptographic verification

Follows Microsoft Authenticode PE specification v1.1

## Description

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran it against copies of bootmgfw.efi and hellouefi.efi that were both singly signed and 
## Integration Instructions

N/A