### PR TITLE
Fix: Update dbx_info_msft_latest.json to correct incorrect guids

### DIFF
--- a/PreSignedObjects/DBX/dbx_info_msft_latest.json
+++ b/PreSignedObjects/DBX/dbx_info_msft_latest.json
@@ -6915,7 +6915,7 @@
             "value": "019D2EF8E827E15841A4884C18ABE2F284000003000000000000000000000000",
             "version": "3.0",
             "filename": "cdboot.efi",
-            "guid": "{e8f82e9d-e127-4158-88a4-4c18abe2f284} == EFI_CDBOOT_DBXSVN_GUID",
+            "guid": "{e8f82e9d-e127-4158-a488-4c18abe2f284} == EFI_CDBOOT_DBXSVN_GUID",
             "description": "Windows cdboot SVN CVE-2023-24932",
             "dateOfLastChange": "2024-04-01"
         },
@@ -6923,7 +6923,7 @@
             "value": "01C2CA99C9FE7F6F4981279E2A8A535976000003000000000000000000000000",
             "version": "3.0",
             "filename": "wdsmgfw.efi",
-            "guid": "{c999cac2-7ffe-496f-2781-9e2a8a535976} == EFI_WDSMGR_DBXSVN_GUID",
+            "guid": "{c999cac2-7ffe-496f-8127-9e2a8a535976} == EFI_WDSMGR_DBXSVN_GUID",
             "description": "Windows wdsmgfw SVN CVE-2023-24932",
             "dateOfLastChange": "2024-04-01"
         }


### PR DESCRIPTION
## Description

REF: https://github.com/microsoft/secureboot_objects/issues/377

Specifically, the following guids were incorrect and have been updated to match the correct values:
    - `"guid": "{e8f82e9d-e127-4158-a488-4c18abe2f284} == EFI_CDBOOT_DBXSVN_GUID",`
    - `"guid": "{c999cac2-7ffe-496f-8127-9e2a8a535976} == EFI_WDSMGR_DBXSVN_GUID",`

The following guid was previously corrected in https://github.com/microsoft/secureboot_objects/pull/404
    - `"guid": "{9d132b61-59d5-4388-ab1c-185c3cb2eb92} == EFI_BOOTMGR_DBXSVN_GUID",`

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [X] Includes documentation?

## How This Was Tested

N/A


## Integration Instructions

N/A