### PR TITLE
Fix bootmgr SVN dateOfLastChange and CVE description (#444)

### DIFF
--- a/PreSignedObjects/DBX/dbx_info_msft_latest.json
+++ b/PreSignedObjects/DBX/dbx_info_msft_latest.json
@@ -7041,8 +7041,8 @@
             "version": "9.0",
             "filename": "bootmgfw.efi",
             "guid": "{9d132b61-59d5-4388-ab1c-185c3cb2eb92} == EFI_BOOTMGR_DBXSVN_GUID",
-            "description": "Windows Bootmgr SVN CVE-2023-24932",
-            "dateOfLastChange": "2026-04-10"
+            "description": "Windows Bootmgr SVN CVE-2026-45654",
+            "dateOfLastChange": "2026-05-21"
         },
         {
             "value": "019D2EF8E827E15841A4884C18ABE2F284000003000000000000000000000000",


### PR DESCRIPTION
## Description

The SVN bump from 8.0 to 9.0 (a728996) updated the value and version of the bootmgfw.efi SVN entry but left dateOfLastChange at the 8.0 date (2026-04-10) and the description at the old CVE (CVE-2023-24932).

Update both fields to match the June 9, 2026 KB5094126 rollout:

- dateOfLastChange: 2026-04-10 -> 2026-05-21

- description: CVE-2023-24932 -> CVE-2026-45654

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

verified that the json was valid

## Integration Instructions

N/A