### PR TITLE
Remove check for existing boot.stl. Copy providing source exists. Res…

### DIFF
--- a/scripts/windows/Make2023BootableMedia.ps1
+++ b/scripts/windows/Make2023BootableMedia.ps1
@@ -909,8 +909,6 @@ function Copy-2023BootBins {
         $bootStlDest = $global:Temp_Media_To_Update_Path + "\EFI\Microsoft\Boot\boot.stl"
         if (-not (Test-Path -Path $bootStlSource)) {
             Write-Dbg-Host "[boot.stl] not found in mounted boot.wim at [$bootStlSource]. Skipping."
-        } elseif (Test-Path -Path $bootStlDest) {
-            Write-Dbg-Host "[boot.stl] already exists at [$bootStlDest]. Preserving existing file."
         } else {
             Write-Dbg-Host "Copying [$bootStlSource] to [$bootStlDest]"
             Copy-Item -Path $bootStlSource -Destination $bootStlDest -Force -ErrorAction stop | Out-Null


### PR DESCRIPTION
…ults in only requiring 2023 Certs in DB, having 2011 in DB is required for previous script.

## Description

I have found that an ISO Passed through this script will still depend on the 2011 Certs in Secure Boot.
I did some testing and found that the implementation of the boot.stl file is flawed, if the boot.stl already exists, which is the case for a Golden ISO downloaded from the MSFT website, it will not be overwritten and will depend on the 2011 certs being in the DB List.
After changing that section a bit, removing the check for the destination boot.stl, causing an overwrite, results in the resulting ISO being bootable with the 2011 Certs in the DBX List, and only 2023 Certs in the DB List.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [X] Impacts functionality?
- [X] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. Downloaded Windows 11 25H2 v2 ISO from MSFT Website.
2. Ran it through previous script
3. Attempted to boot installation media on a system with only the 2023 CA Certificates in the Secure Boot Database.
4. Stopped as a Secure Boot violation message
5. Removed the existing boot.stl check
6. Ran ISO through updated script
7. Attempted to boot installation media on a system with only the 2023 CA Certificates in the Secure Boot Database.
8. Booted successfully to the Windows Setup Screen


## Integration Instructions

Remove the check for the destination boot.stl file in the Make2023BootableMedia.ps1 script.
