### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   apply:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   sync:
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/prepare-binaries.yml
+++ b/.github/workflows/prepare-binaries.yml
@@ -32,19 +32,19 @@ jobs:
 
     steps:
     - name: Checkout Self
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Generate Token
       if: github.event_name == 'release'
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ vars.MU_ACCESS_APP_ID }}
         private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.12
         cache: 'pip'
@@ -80,7 +80,7 @@ jobs:
       run: python scripts/secure_boot_default_keys.py --keystore Templates/LegacyFirmwareDefaults.toml -o FirmwareArtifacts
 
     - name: Upload Firmware Binaries as Artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Binaries
         path: FirmwareArtifacts/
@@ -90,7 +90,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
 
     - name: Upload Firmware Release Archive
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       if: startsWith(github.ref, 'refs/tags/') && !endsWith(github.event.release.tag_name, '-signed')
       with:
         files: ReleaseFirmwareArchive/*
@@ -101,7 +101,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
 
     - name: Upload Signed Release Archive
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       if: startsWith(github.ref, 'refs/tags/') && endsWith(github.event.release.tag_name, '-signed')
       with:
         files: ReleaseSignedArtifacts/*

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Check for Validation Errors
         if: env.VALIDATION_ERROR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('PR Formatting Validation Check Failed!')

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,5 +29,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   check:
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,5 +20,5 @@ on:
 jobs:
   triage:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/validate-kek-updates.yml
+++ b/.github/workflows/validate-kek-updates.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # Need full history to compare with base branch
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.12
         cache: 'pip'
@@ -191,7 +191,7 @@ jobs:
 
     - name: Upload Validation Results
       if: steps.changed-files.outputs.has_changes == 'true' && always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: kek-validation-results
         path: kek_validation_results/
@@ -201,7 +201,7 @@ jobs:
       id: app-token
       if: steps.changed-files.outputs.has_changes == 'true' && always()
       continue-on-error: true
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ vars.MU_ACCESS_APP_ID }}
         private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
@@ -210,7 +210,7 @@ jobs:
     - name: Comment on PR
       if: steps.changed-files.outputs.has_changes == 'true' && failure() && steps.app-token.outputs.token
       continue-on-error: true
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |
@@ -247,7 +247,7 @@ jobs:
     - name: Update PR Comment on Success
       if: steps.changed-files.outputs.has_changes == 'true' && success() && steps.app-token.outputs.token
       continue-on-error: true
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). This groups Dependabot PRs for GitHub Actions and enforces a minimum 7-day cooldown between updates. If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
