### PR TITLE
scripts: fix signed release archives for restructured DBX

### DIFF
--- a/scripts/information/signed_binaries_information.md
+++ b/scripts/information/signed_binaries_information.md
@@ -31,6 +31,22 @@ Background:
     - These binaries are the most compatible with the most systems consult the
     `PreSignedObjects\DBX\dbx_info_msft_<date>.json` file for more information.
 
+## edk2-2023-signed-secureboot-binaries
+
+[!IMPORTANT]
+Background:
+    - These binaries are signed with a leaf certificate of the Microsoft Corporation KEK CA 2023.
+    - These binaries should be used for systems that trust the Microsoft Corporation KEK CA 2023 certificate.
+    - These binaries hashes are broken up by architecture
+        - X64
+        - Ia32
+        - Arm
+        - Aarch64
+    - Purely hash based revocations. These do not contain the 2011 Windows CA nor do they contain SVNs.
+    - These binaries carry the same DBX revocations as the `edk2-2011-signed-secureboot-binaries`, but
+    are signed with the 2023 KEK for systems that have transitioned to it. Consult the
+    `PreSignedObjects\DBX\dbx_info_msft_<date>.json` file for more information.
+
 ## edk2-2011-optional-signed-secureboot-binaries
 
 [!IMPORTANT]

--- a/scripts/prepare_signed_binaries.py
+++ b/scripts/prepare_signed_binaries.py
@@ -18,8 +18,9 @@ INFORMATION = (pathlib.Path(__file__).parent / "information" / "signed_binaries_
 LICENSE = (pathlib.Path(__file__).parent.parent / "License.txt").read_text()
 
 LAYOUT = {
-    "edk2-2011-signed-secureboot-binaries": "DBX",
-    "edk2-2011-optional-signed-secureboot-binaries": "Optional",
+    "edk2-2011-signed-secureboot-binaries": ["SignedByKEK2011"],
+    "edk2-2023-signed-secureboot-binaries": ["SignedByKEK2023"],
+    "edk2-2011-optional-signed-secureboot-binaries": ["Optional"],
 }
 
 def main() -> int:
@@ -50,18 +51,25 @@ def main() -> int:
     readme_path = out_path / "README.md"
     readme_path.write_text(readme)
 
-    for name, arch in LAYOUT.items():
+    for name, sources in LAYOUT.items():
         tmp_dir = tempfile.TemporaryDirectory()
-        pathlib.Path(tmp_dir.name, "version").write_text(args.version)
-        if not (in_path / arch).exists():
-            raise RuntimeError(f"Missing {arch} directory in {in_path}")
-        shutil.copytree(in_path / arch, pathlib.Path(tmp_dir.name), dirs_exist_ok=True)
-
         tmp_path = pathlib.Path(tmp_dir.name)
-        for bin_file in tmp_path.rglob("*.bin"):
-            receipt = get_signed_payload_receipt(bin_file)
+        (tmp_path / "version").write_text(args.version)
+
+        for source in sources:
+            source_path = in_path / source
+            if not source_path.exists():
+                raise RuntimeError(f"Missing {source} directory in {in_path}")
+            # When an archive draws from a single source directory, its contents are
+            # placed at the archive root. When it aggregates multiple source directories,
+            # each is preserved under its own subfolder to keep them distinct.
+            destination = tmp_path if len(sources) == 1 else tmp_path / source
+            shutil.copytree(source_path, destination, dirs_exist_ok=True)
+
+        for signed_file in (*tmp_path.rglob("*.bin"), *tmp_path.rglob("*.efiauth2")):
+            receipt = get_signed_payload_receipt(signed_file)
             receipt_json = json.dumps(receipt, indent=4)
-            receipt_path = bin_file.with_suffix('.json')
+            receipt_path = signed_file.with_suffix('.json')
             receipt_path.write_text(receipt_json)
 
         shutil.make_archive(out_path / name, "zip", tmp_dir.name)


### PR DESCRIPTION


## Description

The PostSignedObjects restructure removed the DBX directory in favor of SignedByKEK2011 and SignedByKEK2023, which broke the signed release archive step in prepare_signed_binaries.py. Map the existing edk2-2011-signed archive to SignedByKEK2011, add a new edk2-2023-signed archive for SignedByKEK2023, and generate receipts for .efiauth2 files in addition to .bin. Document the new 2023 archive in signed_binaries_information.md.
For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Locally

## Integration Instructions

N/A